### PR TITLE
Limit angular velocity but leave velocity for now

### DIFF
--- a/lua/autorun/server/sv_speedlimits_setup.lua
+++ b/lua/autorun/server/sv_speedlimits_setup.lua
@@ -1,11 +1,12 @@
-local magicNumber = 11784960000
+local maxVelocity = 11784960000 -- Default is exactly: 4000
+local maxAngularVelocity = 100000 -- Default is exactly: 7272.7280273438
 
 hook.Add( "InitPostEntity", "CFC_SpeedLimits_Setup", function()
     ORIGINAL_PERFORMANCE_SETTINGS = physenv.GetPerformanceSettings()
 
     local tbl = table.Copy( ORIGINAL_PERFORMANCE_SETTINGS )
-    tbl.MaxAngularVelocity = magicNumber
-    tbl.MaxVelocity = magicNumber
+    tbl.MaxAngularVelocity = maxAngularVelocity
+    tbl.MaxVelocity = maxVelocity
 
     physenv.SetPerformanceSettings( tbl )
 end )


### PR DESCRIPTION
From testing the biggest issue is angular velocity, lowering this might lower the amount of crazy-physics drastically.